### PR TITLE
Include 'main' file in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "angular-jquery",
   "version": "0.2.1",
+  "main": [
+    "dist/angular-jquery.js"
+  ],
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
Include angular-jquery.js as main file so it can be resolved and included automatically by tools like wiredep.
