### PR TITLE
gulp support, solve the bug: mgcrea.jquery cannot be found

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular-jquery",
   "version": "0.2.1",
   "description": "jQuery-like extension for AngularJS embedded jQLite",
+  "main": "dist/angular-jquery.js",
   "keywords": [
     "angular"
   ],


### PR DESCRIPTION
The pull request is to solve a problem that I encountered when processing module angular-jquery with gulp.

Thanks